### PR TITLE
fix: make write file accesses work with GAE

### DIFF
--- a/TEQST/recordingmgmt/models.py
+++ b/TEQST/recordingmgmt/models.py
@@ -87,8 +87,12 @@ class TextRecording(models.Model):
         sentences = self.text.get_content()
         wav_path_rel = Path(self.audiofile.name).stem
 
+        # accessing files from their FileFields in write mode under the use of the GoogleCloudStorage from django-storages
+        # causes errors. Opening files in write mode from the storage works.
         with default_storage.open(self.stmfile.name, 'wb') as stm_file:
             with default_storage.open(self.audiofile.name, 'wb') as audio_full:
+                # since the wave library internally uses python's standard open() method to open files
+                # it needs to be handed an already opened file when working with Google Cloud storage
                 wav_full = wave.open(audio_full, 'wb')
                 for srec in self.srecs.all():
                     with srec.audiofile.open('rb') as srec_audio:

--- a/TEQST/recordingmgmt/models.py
+++ b/TEQST/recordingmgmt/models.py
@@ -87,10 +87,12 @@ class TextRecording(models.Model):
         sentences = self.text.get_content()
         wav_path_rel = Path(self.audiofile.name).stem
 
-        with self.stmfile.open('wb') as stm_file:
-            with wave.open(self.audiofile.open('wb'), 'wb') as wav_full:
+        with default_storage.open(self.stmfile.name, 'wb') as stm_file:
+            with default_storage.open(self.audiofile.name, 'wb') as audio_full:
+                wav_full = wave.open(audio_full, 'wb')
                 for srec in self.srecs.all():
-                    with wave.open(srec.audiofile.open('rb'), 'rb') as wav_part:
+                    with srec.audiofile.open('rb') as srec_audio:
+                        wav_part = wave.open(srec_audio, 'rb')
 
                         #On concatenating the first file: also copy all settings
                         if current_timestamp == 0:
@@ -107,6 +109,8 @@ class TextRecording(models.Model):
 
                         #copy audio
                         wav_full.writeframesraw(wav_part.readframes(wav_part.getnframes()))
+                        wav_part.close()
+                wav_full.close()
         
         self.text.shared_folder.concat_stms()
 

--- a/TEQST/textmgmt/models.py
+++ b/TEQST/textmgmt/models.py
@@ -136,7 +136,7 @@ class SharedFolder(Folder):
         #return "/tmp/download.zip"
 
     def concat_stms(self):
-        with self.stmfile.open('wb') as full:
+        with default_storage.open(self.stmfile.name, 'wb') as full:
             
             speakers = set()
             for text in self.text.all():
@@ -165,13 +165,14 @@ class SharedFolder(Folder):
         file_content = b''
         with self.logfile.open('rb') as log:
             file_content = log.read()
-        with self.logfile.open('wb') as log:
-            logfile_entry = 'username: ' + str(user.username) + '\n' \
-                            + 'email: ' + str(user.email) + '\n' \
-                            + 'date_joined: ' + str(user.date_joined) + '\n' \
-                            + 'birth_year: ' + str(user.birth_year) + '\n#\n'
-            file_content += bytes(logfile_entry, encoding='utf-8')
-            log.write(file_content)
+        
+        logfile_entry = 'username: ' + str(user.username) + '\n' \
+                        + 'email: ' + str(user.email) + '\n' \
+                        + 'date_joined: ' + str(user.date_joined) + '\n' \
+                        + 'birth_year: ' + str(user.birth_year) + '\n#\n'
+        file_content += bytes(logfile_entry, encoding='utf-8')
+        with default_storage.open(self.logfile.name, 'wb') as logw:
+            logw.write(file_content)
 
 
 

--- a/TEQST/textmgmt/models.py
+++ b/TEQST/textmgmt/models.py
@@ -136,6 +136,8 @@ class SharedFolder(Folder):
         #return "/tmp/download.zip"
 
     def concat_stms(self):
+        # accessing files from their FileFields in write mode under the use of the GoogleCloudStorage from django-storages
+        # causes errors. Opening files in write mode from the storage works.
         with default_storage.open(self.stmfile.name, 'wb') as full:
             
             speakers = set()
@@ -171,6 +173,8 @@ class SharedFolder(Folder):
                         + 'date_joined: ' + str(user.date_joined) + '\n' \
                         + 'birth_year: ' + str(user.birth_year) + '\n#\n'
         file_content += bytes(logfile_entry, encoding='utf-8')
+        # accessing files from their FileFields in write mode under the use of the GoogleCloudStorage from django-storages
+        # causes errors. Opening files in write mode from the storage works.
         with default_storage.open(self.logfile.name, 'wb') as logw:
             logw.write(file_content)
 


### PR DESCRIPTION
I changed the places in which we access files in write mode back to an earlier (admittedly less pretty) implementation, which works for the django-storages library when working with Google Cloud.